### PR TITLE
feat: #34 Gemfile.lockの設定も同期

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,9 +212,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails-i18n (7.0.9)
-      i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -298,7 +295,6 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
-  rails-i18n
   selenium-webdriver
   sorcery
   sprockets-rails


### PR DESCRIPTION
Closes #

## 概要
- Gemfile.lockの設定も同期

## やったこと
- Gemfileからrails-i18nというgemをアンインストールしたが、Gemfile.lockの設定の方に同期できていなかったため、そちらの設定も行った。

## やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- なし

## その他
- なし

## 関連Issue
- 関連Issue: #34

