### PR TITLE
Feature/#6 フラッシュメッセージの設定

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,9 +7,10 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path
+      redirect_to root_path, notice: 'ログインしました'
     else
-      render :new
+      flash.now[:alert] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path
+      redirect_to root_path, notice: 'ユーザー登録が完了しました'
     else
-      render :new
+      flash.now[:alert] = 'ユーザー登録に失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :notice then "bg-green-500"
+    when :alert  then "bg-red-500"
+    when :error  then "bg-yellow-500"
+    else "bg-gray-500"
+    end
+  end
 end

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-2">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,10 @@
 
   <body>
     <div class="font-body-jp bg-gray-200">
+      <%# フラッシュメッセージ %>
+      <%= render 'layouts/flash_messages' %>
+
+      <%# ヘッダー（ログイン有無で出しわけ） %>
       <% if logged_in? %>
         <%= render 'shared/header' %>
       <% else %>
@@ -19,6 +23,8 @@
       <% end %>
 
       <%= yield %>
+
+      <%# フッター %>
       <%= render 'shared/footer' %>
     </div>
   </body>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -8,7 +8,7 @@
             </div>
             <div class="mb-3">
                 <%= f.label 'パスワード' %>
-                <%= f.password_field :password, class: "form-control" %>
+                <%= f.password_field :password, placeholder: '4文字以上', class: "form-control" %>
             </div>
             <div class="flex justify-center">
                 <%= f.submit 'ログイン', class: "btn btn-primary" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,11 +12,11 @@
             </div>
             <div class="mb-3">
                 <%= f.label 'パスワード', class: "form-label" %>
-                <%= f.password_field :password, class: "form-control" %>
+                <%= f.password_field :password, placeholder: '4文字以上', class: "form-control" %>
             </div>
             <div class="mb-3">
                 <%= f.label 'パスワード確認', class: "form-label" %>
-                <%= f.password_field :password_confirmation, class: "form-control" %>
+                <%= f.password_field :password_confirmation, placeholder: '4文字以上', class: "form-control" %>
             </div>
             <div class="flex justify-center">
                 <%= f.submit '登録', class: "btn btn-primary" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,5 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # デフォルトの言語設定を日本語にする
-    config.i18n.default_locale = :ja
   end
 end


### PR DESCRIPTION
Closes #38

## 概要
- tailwindでのフラッシュメッセージが表示されるように設定する

## やったこと
- ヘルパーメソッドとして背景の色を指定する関数を定義
- フラッシュメッセージのパーシャルファイルを用意する
- メインのレイアウトファイルでパーシャルファイルを呼び出す
- コントローラでの記述
- daisyUIを用いてフラッシュメッセージのカラー設定

## やらないこと
- なし

## できるようになること（ユーザ目線）
- ユーザー登録とログインに関係するフォーム送信の際、フラッシュメッセージが表示されるようになる

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ローカル環境でフラッシュメッセージが表示されることを確認

## その他
- なし

## 関連Issue
- 関連Issue: #38

