### PR TITLE
Feature/#7 google maps api導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.bundle
 
 # Ignore all environment files (except templates).
+/.env
 /.env*
 !/.env*.erb
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "bootsnap", require: false
 gem 'sorcery'
 
 # 秘匿情報保護用のgem
-gem 'dotenv-rails'
+gem 'dotenv', groups: [:development, :test]
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ gem "bootsnap", require: false
 # ユーザー登録用のgem
 gem 'sorcery'
 
+# 秘匿情報保護用のgem
+gem 'dotenv-rails'
+
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.2)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.10.1)
@@ -290,6 +291,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# アプリ起動時に.envに記述した環境変数を読み込む(Google Maps APIのAPIキーなど)
+Dotenv::Railtie.load
+
 module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
Closes #43 
Closes #44 

## 概要
- Google Maps APIの中で、どのAPIを利用するかの調査
- gemの中で、どのgemを利用するかの調査
- gem 'dotenv'の導入
- Google Maps APIの導入

## やったこと
### APIとgemの選定
- Google Maps APIの中で、どのAPIを利用するか選定
- gemの中で、どのgemを利用するかの調査
両者の結果は、該当のissue( #43 )のコメントに記載。→　[リンク](https://github.com/Yuki11saitou/LearnLocator/issues/43#issuecomment-2274230097)

### Google Maps APIの導入
- gem 'dotenv'の導入（開発環境、テスト環境で秘匿情報管理を担う）
- Google Maps APIキーの発行
- Google Maps API（JavaScript API、Places API、Geocording API）の有効化
- デプロイ先であるRenderでのGoogle Maps APIキーの設定（本番環境での秘匿情報管理を担う）

## やらないこと
- gem 'dotenv'以外のgemは導入をせず、別issueとする。（gem ‘google_places’ / gem 'geocoder' / gem 'gmaps4rails’)

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- 開発環境において、試験的に、JavaScript APIを利用してMapが表示されることを確認（APIが利用できていることを確認）
  - 参考記事
    - https://qiita.com/lemonade_37/items/51ca0f18fd9da842bb00
    - https://qiita.com/nagase_toya/items/e49977efb686ed05eadb

## その他
- なし

## 関連Issue
- 関連Issue: #43 #44

