### PR TITLE
chore: #44 gem'dotenv'ではなく'dotenv-railsを導入'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "bootsnap", require: false
 gem 'sorcery'
 
 # 秘匿情報保護用のgem
-gem 'dotenv', groups: [:development, :test]
+gem 'dotenv-rails', groups: [:development, :test]
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.10.1)
@@ -291,7 +294,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
-  dotenv
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)


### PR DESCRIPTION
Closes #

## 概要
- gem 'dotenv'を導入していたが、gem 'dotenv-rails'の間違いだったため導入し直し

## やったこと
- ｇem 'dotenv-rails'の間違いだったため導入し直し

## やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- なし

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 

## 関連Issue
- 関連Issue: #43 #44

