### PR TITLE
chore: #44 application.rbの環境変数読み込み設定をなくす

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,9 +6,6 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# アプリ起動時に.envに記述した環境変数を読み込む(Google Maps APIのAPIキーなど)
-Dotenv::Railtie.load
-
 module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
Closes #

## 概要
- 環境変数の読み込み設定をなくす

## やったこと
- application.rbの環境変数読み込み設定を設けていたが、これが不要の可能性があり削除。

## やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- なし

## その他
- なし

## 関連Issue
- 関連Issue: #43 #44

