### PR TITLE
feat: #97 場所検索ページ用意

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,0 +1,5 @@
+class SpotsController < ApplicationController
+  skip_before_action :require_login
+
+  def map; end
+end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <div class="btm-nav">
 
-    <%= link_to root_path, class: "hover:bg-gray-300" do %>
+    <%= link_to spots_map_path, class: "hover:bg-gray-300" do %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 576 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M565.6 36.2C572.1 40.7 576 48.1 576 56l0 336c0 10-6.2 18.9-15.5 22.4l-168 64c-5.2 2-10.9 2.1-16.1 .3L192.5 417.5l-160 61c-7.4 2.8-15.7 1.8-22.2-2.7S0 463.9 0 456L0 120c0-10 6.1-18.9 15.5-22.4l168-64c5.2-2 10.9-2.1 16.1-.3L383.5 94.5l160-61c7.4-2.8 15.7-1.8 22.2 2.7zM48 136.5l0 284.6 120-45.7 0-284.6L48 136.5zM360 422.7l0-285.4-144-48 0 285.4 144 48zm48-1.5l120-45.7 0-284.6L408 136.5l0 284.6z"/></svg>
         <span class="text-sm btm-nav-label">場所検索</span>
     <% end %>

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -1,0 +1,74 @@
+<h2>Google Map Test</h2>
+<input id="address" type="textbox" value="">
+<input type="button" value="送信" onclick="codeAddress()">
+<input type="button" value="現在地を表示" onclick="showCurrentLocation()">
+<div id="latlngDisplay">ここに緯度、経緯が表示される</div>
+<div id="addressDisplay">ここに住所が表示される</div>
+<div id="map"></div>
+
+<style>
+#map {
+    height: 600px;
+    width: 600px;
+}
+</style>
+
+<script>
+let map, marker;
+
+const latlngDis = document.getElementById('latlngDisplay');
+const addressDis = document.getElementById('addressDisplay');
+
+function initMap() {
+    const geocoder = new google.maps.Geocoder();
+
+    map = new google.maps.Map(document.getElementById('map'), {
+        zoom: 12,
+    });
+
+    marker = new google.maps.Marker({
+        map: map,
+    });
+    showCurrentLocation();
+}
+
+function codeAddress() {
+    const geocoder = new google.maps.Geocoder();
+    const inputAddress = document.getElementById('address').value;
+    geocoder.geocode({ 'address': inputAddress }, function(results, status) {
+        if (status === 'OK') {
+        map.setCenter(results[0].geometry.location);
+        marker.setPosition(results[0].geometry.location);
+        latlngDis.innerHTML = `Latitude: ${results[0].geometry.location.lat()}, Longitude: ${results[0].geometry.location.lng()}`;
+        addressDis.innerHTML = results[0].formatted_address;
+        } else {
+        alert("該当する結果がありませんでした：" + status);
+        }
+    });
+}
+
+function showCurrentLocation(){
+    // ユーザーの現在地を取得してマップに設定
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(function(position) {
+        const userLocation = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+        };
+        map.setCenter(userLocation);
+        marker.setPosition(userLocation);
+        latlngDis.innerHTML = `Latitude: ${userLocation.lat}, Longitude: ${userLocation.lng}`;
+        }, function() {
+        alert('位置情報の取得に失敗しました。');
+        map.setCenter({ lat: 35.6803997, lng: 139.7690174 }); // 東京の座標
+        });
+    } else {
+      // Geolocationがサポートされていないブラウザの場合
+        alert('お使いのブラウザでは地理位置情報の取得がサポートされていません。');
+      map.setCenter({ lat: 35.6803997, lng: 139.7690174 }); // 東京の座標
+    };
+}
+
+</script>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -10,7 +10,7 @@
         </div>
     </div>
     <div class="mt-6">
-        <%= link_to "#", class: "btn btn-primary rounded hover:bg-gray-300 hover:text-rose-400" do %>
+        <%= link_to spots_map_path, class: "btn btn-primary rounded hover:bg-gray-300 hover:text-rose-400" do %>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 576 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M565.6 36.2C572.1 40.7 576 48.1 576 56l0 336c0 10-6.2 18.9-15.5 22.4l-168 64c-5.2 2-10.9 2.1-16.1 .3L192.5 417.5l-160 61c-7.4 2.8-15.7 1.8-22.2-2.7S0 463.9 0 456L0 120c0-10 6.1-18.9 15.5-22.4l168-64c5.2-2 10.9-2.1 16.1-.3L383.5 94.5l160-61c7.4-2.8 15.7-1.8 22.2 2.7zM48 136.5l0 284.6 120-45.7 0-284.6L48 136.5zM360 422.7l0-285.4-144-48 0 285.4 144 48zm48-1.5l120-45.7 0-284.6L408 136.5l0 284.6z"/></svg>
             探してみる
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,7 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
+  # 場所検索ページのルーティング
+  get 'spots/map'
+
 end


### PR DESCRIPTION
Closes #97

## 概要
- 場所検索ページの用意

## やったこと
- 場所検索ページのルーティング、コントローラー、ビューの設定する
- ビューには、試験的にAPIを利用しMapを表示

## やらないこと
- なし

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ローカル環境でページ遷移が問題ないことを確認
- ローカルでMapが表示されることを確認

## その他
- なし

## 関連Issue
- 関連Issue: #97

