### PR TITLE
feat: #99 必要gemの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,15 @@ gem 'sorcery'
 # 秘匿情報保護用のgem
 gem 'dotenv-rails', groups: [:development, :test]
 
+# GooglePlacesAPIを使用、条件つき検索、店舗情報などの取得のためのgem
+gem 'google_places'
+
+# GeoderdingAPIを使用、緯度経度から住所を取得、現在地を取得するためのgem
+gem 'geocoder'
+
+# Google Places APIを利用、オートコンプリート機能、インフォウィンドウの表示などのためのgem
+gem 'gmaps4rails'
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -113,9 +114,19 @@ GEM
       logger
     faraday-net_http (3.1.1)
       net-http
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gmaps4rails (2.1.2)
+    google_places (2.0.0)
+      httparty (>= 0.13.1)
     hashie (5.0.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -295,6 +306,9 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  geocoder
+  gmaps4rails
+  google_places
   jbuilder
   jsbundling-rails
   pg (~> 1.1)


### PR DESCRIPTION
Closes #99

## 概要
- Google Maps API を使用する上で必要と判断したgemを導入する

## やったこと
- gem ‘google_places’導入
- gem 'geocoder'導入
- gem 'gmaps4rails’導入

## やらないこと
- 

## できるようになること（ユーザ目線）
- 

## できなくなること（ユーザ目線）
- 

## 動作確認
- ターミナル上でgemのインストール完了を確認

## その他
- 

## 関連Issue
- 関連Issue: #99

