### PR TITLE
Feature/#10 spots,categoriesテーブル作成

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
   has_many :spots
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,3 @@
 class Category < ApplicationRecord
+  has_many :spots
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,0 +1,2 @@
+class Spot < ApplicationRecord
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,2 +1,6 @@
 class Spot < ApplicationRecord
+  belongs_to :category
+  geocoded_by :address
+  after_validation :geocode
+  validates :name, :latitude, :longitude, :place_id, presence: true, uniqueness: true
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,13 +1,13 @@
 Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
-  # lookup: :nominatim,         # name of geocoding service (symbol)
+  lookup: :google,                                   # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
-  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  use_https: true,                                   # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  # api_key: nil,               # API key for geocoding service
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default

--- a/db/migrate/20240810121903_create_categories.rb
+++ b/db/migrate/20240810121903_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :categories, :name, unique: true
+  end
+end

--- a/db/migrate/20240810130027_create_spots.rb
+++ b/db/migrate/20240810130027_create_spots.rb
@@ -1,0 +1,8 @@
+class CreateSpots < ActiveRecord::Migration[7.1]
+  def change
+    create_table :spots do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240810130027_create_spots.rb
+++ b/db/migrate/20240810130027_create_spots.rb
@@ -1,7 +1,18 @@
 class CreateSpots < ActiveRecord::Migration[7.1]
   def change
     create_table :spots do |t|
-
+      t.references :category, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :postal_code
+      t.string :address
+      t.string :phone_number
+      t.string :opening_hours
+      t.string :web_site
+      t.decimal :rating
+      t.decimal :latitude, precision: 10, scale: 7, null: false
+      t.decimal :longitude, precision: 10, scale: 7, null: false
+      t.string :place_id, null: false
+      t.string :photo_reference
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_10_121903) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_10_130027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_10_121903) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "spots", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "name", null: false
+    t.string "postal_code"
+    t.string "address"
+    t.string "phone_number"
+    t.string "opening_hours"
+    t.string "web_site"
+    t.decimal "rating"
+    t.decimal "latitude", precision: 10, scale: 7, null: false
+    t.decimal "longitude", precision: 10, scale: 7, null: false
+    t.string "place_id", null: false
+    t.string "photo_reference"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_spots_on_category_id"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -39,4 +57,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_10_121903) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "spots", "categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_183125) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_10_121903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.string "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,13 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# カテゴリーの初期データ
+Category.create!(
+  [
+    {name: '自習室'},
+    {name: 'コワーキングスペース'},
+    {name: '図書館'},
+    {name: 'カフェ'}
+  ]
+)

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/spots.yml
+++ b/test/fixtures/spots.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/spot_test.rb
+++ b/test/models/spot_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SpotTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Closes #48

## 概要
- spots,categoriesテーブル作成
- 上記に伴いSpot,Categoryモデルの作成・設定
- gem 'geocoder'の設定

## やったこと
- spots,categoriesテーブル作成
  - それぞれ、DBにテーブルを作成した
  - categoriesテーブルに関しては、内容が決まっており、変更の予定もないため、seeds.rbにデータを記載しDBに登録した
- 上記に伴いSpot,Categoryモデルの作成・設定
  - 現時点で考えられるアソシエーションの設定
  - 現時点で考えられるバリデーションの設定
- gem 'geocoder'の設定

## やらないこと
- spotsテーブルに対するデータの登録

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）
- なし

## 動作確認
- ターミナル上で、spotsテーブルとcategoriesテーブルが作成されていることを確認
- 上記と同様に、意図したカラムが登録されているかも確認

## その他
- なし

## 関連Issue
- 関連Issue: #48

