### PR TITLE
style: #105 svg読み込み漏れを追記修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,6 @@
 <div class="navbar bg-gray-100">
     <div class="flex-1">
+        <%= image_tag 'LearnLocator_logo.png', class: "h-10 ml-2" %>
         <%= link_to 'LearnLocater', root_path, class: "btn btn-ghost text-xl" %>
     </div>
     <div class="flex-none">


### PR DESCRIPTION
Closes #

## 概要
- svg読み込み漏れを追記修正

## やったこと
- ヘッダーに、ロゴ用のsvgファイルの読み込み設定が漏れていたので、そこを追記修正

## やらないこと
- 

## できるようになること（ユーザ目線）
- 

## できなくなること（ユーザ目線）
- 

## 動作確認
- 

## その他
- 

## 関連Issue
- 関連Issue: #105

