### PR TITLE
Feature/#46 一覧検索画面の並べ替え機能実装

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -7,7 +7,14 @@ class SpotsController < ApplicationController
 
   def index
     @q = Spot.ransack(params[:q])
-    @spots = @q.result(distinct: true).includes(:category).order(created_at: :desc).page(params[:page])
+
+    # 並べ替えが"rating"の場合のみ、ratingがnilのレコードを除外する
+    if params[:q] && params[:q][:s] && params[:q][:s].include?('rating')
+      @spots = @q.result(distinct: true).includes(:category).where.not(rating: nil).order(created_at: :desc).page(params[:page])
+    else
+      @spots = @q.result(distinct: true).includes(:category).order(created_at: :desc).page(params[:page])
+    end
+
     # ソート機能のため、カテゴリを取得(現状、カテゴリID:1(自習室), 2(コワーキング)のみ)
     @categories = Category.where(id: [1, 2])
   end

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -2,14 +2,35 @@
     <div class="m-3">
         <div class="mx-auto flex justify-center">
             <div class="join">
+                <%# 入力欄 %>
                 <%= f.search_field :name_or_address_cont, class: 'input input-bordered join-item text-sm', placeholder: t('search_form.placeholder') %>
-                <%= f.select :category_id_eq, options_from_collection_for_select(@categories, :id, :name, params.dig(:q, :category_id_eq)), { include_blank: t('search_form.facility_type') }, class: 'select select-bordered join-item text-xs' %>
+
+                <%# 施設選択 %>
+                <%= f.select :category_id_eq, options_for_select([
+                    # 施設種別を設定
+                    [t('search_form.select_form.study_room'), 1],
+                    [t('search_form.select_form.co_working_space'), 2]
+                ], params.dig(:q, :category_id_eq)), { include_blank: t('search_form.select_form.facility_type') }, class: 'select select-bordered join-item text-xs' %>
+
+                <%# 検索ボタン %>
                 <div class="indicator">
-                    <%= button_tag(type: 'submit', class: 'btn join-item rounded-r-full') do %>
+                    <%= button_tag(type: 'submit', class: 'btn join-item') do %>
                         <%= image_tag 'search_mark.svg', class: "h-4 w-4" %>
                     <% end %>
                 </div>
             </div>
         </div>
+
+        <%# マーカー説明 %>
+        <div class="mt-1">
+            <div class="flex justify-center items-center">
+                <div class="text-xs font-bold"><%= t('search_form.select_form.study_room') %></div>
+                <div class="text-xs"><%= t('search_form.description.study_room') %></div>
+                <div class="text-xs mx-2"></div>
+                <div class="text-xs font-bold"><%= t('search_form.select_form.co_working_space') %></div>
+                <div class="text-xs"><%= t('search_form.description.co_working_space') %></div>
+            </div>
+        </div>
+
     </div>
 <% end %>

--- a/app/views/spots/_sort_links.html.erb
+++ b/app/views/spots/_sort_links.html.erb
@@ -1,0 +1,24 @@
+<%# todo : 後ほど口コミの並べ替え機能実装 %>
+<%# <%= sort_link(@q, :name, "口コミ数") %>
+
+<div class="w-5/6 mx-auto max-w-sm md:max-w-4xl">
+    <div class="dropdown">
+        <div tabindex="0" role="button" class="btn btn-sm m-1 text-xs">
+            <%= t('sort_link.title') %>
+            <svg class="inline-block h-2 w-2 fill-current opacity-60", xmlns="http://www.w3.org/2000/svg", viewBox="0 0 2048 2048">
+                <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
+            </svg>
+        </div>
+        <ul tabindex="0" class="dropdown-content bg-base-300 rounded-box z-[1] w-52 p-2 shadow-2xl">
+        <li>
+            <%= sort_link(q, '#', "口コミ数", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+        </li>
+        <li>
+            <%= sort_link(q, :name, "名前順", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+        </li>
+        <li>
+            <%= sort_link(q, :rating, t('sort_link.sorted_by_rating'), class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+        </li>
+        </ul>
+    </div>
+</div>

--- a/app/views/spots/_sort_links.html.erb
+++ b/app/views/spots/_sort_links.html.erb
@@ -10,15 +10,15 @@
             </svg>
         </div>
         <ul tabindex="0" class="dropdown-content bg-base-300 rounded-box z-[1] w-52 p-2 shadow-2xl">
-        <li>
-            <%= sort_link(q, '#', "口コミ数", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
-        </li>
-        <li>
-            <%= sort_link(q, :name, "名前順", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
-        </li>
-        <li>
-            <%= sort_link(q, :rating, t('sort_link.sorted_by_rating'), class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
-        </li>
+            <li>
+                <%= sort_link(q, '#', "口コミ数", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+            </li>
+            <li>
+                <%= sort_link(q, :name, "名前順", class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+            </li>
+            <li>
+                <%= sort_link(q, :rating, t('sort_link.sorted_by_rating'), class: "btn btn-sm btn-block btn-ghost justify-start text-xs") %>
+            </li>
         </ul>
     </div>
 </div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -52,7 +52,7 @@
                         <% if spot.web_site.present? %>
                             <%= link_to "公式HPリンク", "#{spot.web_site}", target: :_blank, rel: "noopener noreferrer", class: "link" %>
                         <% else %>
-                            <p><%= t('.no_data') %></p>
+                            <p><%= t('spots.index.no_data') %></p>
                         <% end %>
                     </div>
                 </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -5,10 +5,11 @@
     <form>
         <%= render 'search_form', q: @q, url: spots_path %>
     </form>
+</div>
 
-    <%# todo : 後ほど並べ替え機能実装 %>
-    <%# <%= sort_link(@q, :name, "施設名でソート") %> |
-    <%# <%= sort_link(@q, :created_at, "作成日でソート") %>
+<%# 並べ替え機能 %>
+<div class="mb-3">
+    <%= render 'sort_links', q: @q %>
 </div>
 
 <%# spotデータ(一覧表示) %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -55,6 +55,7 @@ ja:
     index:
       title: 一覧検索
       no_spot_data: データがありません
+      no_data: データがありません
     show:
       no_data: データがありません
       opening_hours: 営業時間

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -63,7 +63,13 @@ ja:
   # 検索フォーム
   search_form:
     placeholder: 施設名/エリア名を入力
-    facility_type: 施設種別
+    select_form:
+      facility_type: 種類
+      study_room: (自)
+      co_working_space: (コ)
+    description:
+      study_room: 自習室
+      co_working_space: コワーキングスペース
   # 並べ替え
   sort_link:
     title: 並べ替え

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -64,6 +64,10 @@ ja:
   search_form:
     placeholder: 施設名/エリア名を入力
     facility_type: 施設種別
+  # 並べ替え
+  sort_link:
+    title: 並べ替え
+    sorted_by_rating: 評価順(googleレビュー)
   # ページネーション
   pagination:
     previous: "«"


### PR DESCRIPTION
Closes #46

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 一覧検索画面の並べ替え機能実装

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 一覧検索画面で使用する並べ替え機能を実装
  - パーシャルファイルを用意し、そこに並べ替えボタンを用意
  - 検索フォームで検索後のデータに対し、並べ替えができるように並べ替え機能を実装
- 検索フォームにレイアウト崩れがあったため修正

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 一覧検索画面にて、検索を行ったデータに対して、Googleの口コミ数などによる並べ替えを行うことが可能になる。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルで検索と並べ替えが問題ないことを確認

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #46
