### PR TITLE
Feature/#52 map表示の不具合修正、レイアウト調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'ransack'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
+  # デバッグ用のgem
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -94,6 +95,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -166,6 +168,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -211,6 +214,12 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -359,6 +368,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   pg (~> 1.1)
+  pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -19,10 +19,8 @@ class SpotsController < ApplicationController
     @categories = Category.where(id: [1, 2])
   end
 
-  # todo : 後で内容精査
   def show
     @spot = Spot.find(params[:id])
-    # @review = Review.new # 口コミ投稿フォーム用なので、ここでは多分不要
     @reviews = @spot.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(3)
   end
 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,12 +12,14 @@
             </div>
             <ul tabindex="0" class="menu dropdown-content bg-base-100 rounded-box z-[1] mt-4 w-52 p-2 shadow">
 
+                <%# todo: リンク先を修正する %>
+
                 <%# 未ログインユーザー向け %>
                 <li><%= link_to t('header.login'), login_path, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.new_register'), new_user_path, class: "text-base hover:text-secondary" %></li>
 
                 <%# 以降共通 %>
-                <li><%= link_to t('header.spot_search'), spots_map_path, class: "text-base hover:text-secondary" %></li>
+                <li><%= link_to t('header.spot_search'), spots_map_path, data: { turbo: false }, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.index_search'), spots_path, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.spot_differences'), difference_path, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.spot_bookmarks'), root_path, class: "text-base hover:text-secondary" %></li>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <div class="btm-nav bg-gray-100">
 
-    <%= link_to spots_map_path, class: "hover:bg-gray-300" do %>
+    <%= link_to spots_map_path, data: { turbo: false }, class: "hover:bg-gray-300" do %>
         <%= image_tag 'location_search.svg', class: "h-4 w-4" %>
         <span class="text-[0.5rem] btm-nav-label"><%= t('footer.spot_search') %></span>
     <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
                 <li><%= link_to t('header.logout'), logout_path, class: "text-base hover:text-secondary", data: { turbo_method: :delete } %></li>
 
                 <%# 以降共通 %>
-                <li><%= link_to t('header.spot_search'), spots_map_path, class: "text-base hover:text-secondary" %></li>
+                <li><%= link_to t('header.spot_search'), spots_map_path, data: { turbo: false }, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.index_search'), spots_path, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.spot_differences'), difference_path, class: "text-base hover:text-secondary" %></li>
                 <li><%= link_to t('header.spot_bookmarks'), root_path, class: "text-base hover:text-secondary" %></li>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,7 +1,27 @@
 <% content_for(:title, @spot.name) %>
 
+<div class="mt-4">
+    <div class="w-5/6 mx-auto max-w-sm md:max-w-4xl">
+        <%# 戻るボタン %>
+        <div class="dropdown dropdown-right">
+            <div tabindex="0" role="button" class="btn btn-sm text-xs">
+                <%= image_tag 'page_back_mark.svg', class: "h-3 w-3" %>
+                <%= t('.back') %>
+            </div>
+            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+                <li>
+                    <%= link_to '位置検索画面へ', spots_map_path, data: { turbo: false }, class: "text-xs" %>
+                </li>
+                <li>
+                    <%= link_to '一覧検索画面へ', spots_path, class: "text-xs" %>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+
 <div class="w-5/6 mx-auto max-w-md">
-    <div class="mt-8">
+    <div class="mt-2">
         <div class="card">
             <div class="m-4">
                 <%# Spot画像 %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -114,7 +114,7 @@
 
                         <%# Google Map 表示エリア %>
                         <div class="mt-6">
-                            <div id="map" class="relative rounded-xl" style="height: 200px;">
+                            <div id="map" class="relative rounded-xl" style="height: 400px;">
                                 <%# マップ読み込み中のローディングリング %>
                                 <div class="absolute inset-0 flex items-center justify-center">
                                     <span class="loading loading-ring loading-lg"></span>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -10,10 +10,10 @@
             </div>
             <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
                 <li>
-                    <%= link_to '位置検索画面へ', spots_map_path, data: { turbo: false }, class: "text-xs" %>
+                    <%= link_to t('.to_spot_search'), spots_map_path, data: { turbo: false }, class: "text-xs" %>
                 </li>
                 <li>
-                    <%= link_to '一覧検索画面へ', spots_path, class: "text-xs" %>
+                    <%= link_to t('.to_index_search'), spots_path, class: "text-xs" %>
                 </li>
             </ul>
         </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -17,7 +17,7 @@
             </div>
         </div>
         <div class="mt-6">
-            <%= link_to spots_map_path, class: "btn btn-primary rounded hover:bg-base-100 hover:text-secondary" do %>
+            <%= link_to spots_map_path, data: { turbo: false }, class: "btn btn-primary rounded hover:bg-base-100 hover:text-secondary" do %>
                 <%= image_tag 'location_search.svg', class: "h-4 w-4" %>
                 <%= t('.spot_search') %>
             <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -62,6 +62,8 @@ ja:
       opening_hours: 営業時間
       to_spot: ここへ行く
       back: 戻る
+      to_spot_search: 場所検索画面へ
+      to_index_search: 一覧検索画面へ
       tab:
         facility_details: 施設詳細
         reviews: 口コミ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -61,6 +61,7 @@ ja:
       no_data: データがありません
       opening_hours: 営業時間
       to_spot: ここへ行く
+      back: 戻る
       tab:
         facility_details: 施設詳細
         reviews: 口コミ


### PR DESCRIPTION
Closes #221
Closes #222 
Closes #224 
Closes #225

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- map表示の不具合修正、レイアウト調整

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 施設詳細画面のMap表示エリアを拡大し、スマホでの操作（ピンチイン・ピンチアウト）が容易になるよう修正
- 【不具合対応】施設詳細画面から場所検索画面に遷移した際のSpot情報を初期化するよう修正
- デバッグ用のgem導入
- 施設詳細画面に「戻る」ボタンを設置し、自然な画面遷移が可能になるよう修正

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 施設詳細画面のMapが見やすく、操作しやすくなる（ピンチイン・ピンチアウト）
- 「戻る」ボタンの設置により、施設詳細画面から元のページに遷移しやすくなる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルで上記不具合が修正されていることを確認
- ローカルで上記「戻るボタン」が有効になっていることを確認

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #221 #222 #224 #225 
