### PR TITLE
Feature/#76 apiの使用制限

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,9 @@ gem 'config'
 # Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem
 gem 'letter_opener_web'
 
+# APIへのリクエスト数を制御するために使用するgem
+gem 'rack-attack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.7)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -473,6 +475,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)
+  rack-attack
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n
   ransack

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>リクエスト制限を超過しました</title>
+</head>
+<body>
+    <div style="text-align: center; margin-top: 50px;">
+        <h1>リクエストが多すぎます</h1>
+        <p>短時間に多くのリクエストを送信しました。少し待ってから再試行してください。</p>
+        <p>このメッセージが続く場合は、お問合せフォームからご連絡ください。</p>
+    </div>
+</body>
+</html>
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,8 @@ module Myapp
 
     # Railsアプリケーションのデフォルトの言語設定を日本語に設定
     config.i18n.default_locale = :ja
+
+    # RailsアプリケーションでRack::Attackをミドルウェアとして使用するための設定
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,9 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
+    # 開発環境でのキャッシュ管理（デフォルトはnull_store）｜これはRack Attackを用いたリクエスト制限のために設定
+    # config.cache_store = :null_store
+    config.cache_store = :memory_store
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,8 +64,12 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
+
+  # Rack Attackを用いたリクエスト制限のために設定(デフォルトの表記は mem_cache_store)
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
+
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,19 @@
+class Rack::Attack
+  # 同一IPアドレスからのリクエストを1分間に60リクエストまでに制限
+  throttle('req/ip', limit: 10, period: 1.minute) do |req|
+    req.ip
+  end
+
+  # 制限を超えたリクエストに対するレスポンスをカスタマイズ
+  self.throttled_response = lambda do |env|
+    # カスタムHTMLレスポンス
+    [
+      429,
+      { 'Content-Type' => 'text/html' },
+      [ApplicationController.render(
+        template: 'errors/too_many_requests',
+        layout: false
+      )]
+    ]
+  end
+end


### PR DESCRIPTION
Closes #157

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- Google Cloud ConsoleでGoogle Maps APIの利用制限をかける
- Rack Attackを利用したリクエスト制限をかける

## やったこと
<!-- このプルリクで何をしたのか？ -->
- Google Cloud ConsoleでGoogle Maps APIの利用制限をかける
- Rack Attackを利用したリクエスト制限をかける

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- F5攻撃のような、攻撃的なリクエスト送信ができなくなる

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で、一定時間に対象のリクエストを送信した際、このような画面が表示されることを確認
[![Image from Gyazo](https://i.gyazo.com/54c0d231ce41ef711af5c42302feaf10.png)](https://gyazo.com/54c0d231ce41ef711af5c42302feaf10)

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 本番環境で、本当に一定時間に対象のリクエストを送信した際に、用意した画面が表示されることを確認してから、issue #309 をCloseとする

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #157 #309
