### PR TITLE
feat: #309 rack attack ファイルで制限に関する設定を正常な値に戻す

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 class Rack::Attack
   # 同一IPアドレスからのリクエストを1分間に60リクエストまでに制限
-  throttle('req/ip', limit: 1, period: 5.seconds) do |req|
+  throttle('req/ip', limit: 60, period: 1.minute) do |req|
     req.ip
   end
 


### PR DESCRIPTION
Closes #309 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- rack attack ファイルで制限に関する設定を正常な値に戻す

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 本番環境で、実際に過剰なリクエストを送った際、エラーページが表示されることを確認したので、制限に関する設定を正常な値に戻す

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 本番環境で、実際に過剰なリクエストを送った際、エラーページが表示されることを確認した

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 一旦、本番環境でもリクエスト過多のときのエラーページが表示されることを確認した。しかし、サーバーの負荷軽減のためか、リクエスト先のサーバーが変更されている可能性があり、一度にたくさんリクエストを送信しても必ずしもエラーページが表示されるとは限らない除隊であった。そのため、今後余裕があれば、Redisを利用することを検討する。

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #309
