### PR TITLE
fix: #342 spot情報のxシェア、ogpが古い画像から切り替わったが、url表示のための施策

### DIFF
--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -91,7 +91,7 @@
                                 <%# Xシェアボタン %>
                                 <li>
                                     <div class="twitter">
-                                        <%= link_to "https://twitter.com/intent/tweet?url=#{spot_url(@spot)}?v=2&text=#{ERB::Util.url_encode("【LearnLocator - 勉強場所検索サービス -】\n\n「#{@spot.name}」をシェアします！\n\n\n\n\n#LearnLocator #勉強場所探し\n\n")}", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
+                                        <%= link_to "https://twitter.com/intent/tweet?url=#{spot_url(@spot)}&text=#{ERB::Util.url_encode("【LearnLocator - 勉強場所検索サービス -】\n\n「#{@spot.name}」をシェアします！\n\n\n\n\n#LearnLocator #勉強場所探し\n\n")}", target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
                                             <%= image_tag 'x_mark.svg', class: "h-5 w-5" %>
                                         <% end %>
                                     </div>


### PR DESCRIPTION
Closes #

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
-  spot情報のxシェア、ogpが古い画像から新しいものに切り替わったが、url表示に追記分の「?v=2」が表示されるため、一時的に元に戻してどうなるか確かめる

## やったこと
<!-- このプルリクで何をしたのか？ -->
-  spot情報のxシェア、ogpが古い画像から新しいものに切り替わったが、url表示に追記分の「?v=2」が表示されるため、一時的に元に戻してどうなるか確かめる

[![Image from Gyazo](https://i.gyazo.com/d5cd0aec203def7247ee78427de39295.png)](https://gyazo.com/d5cd0aec203def7247ee78427de39295)

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #342 
